### PR TITLE
誤字修正 使用する公開鍵のファイル名を '~/.ssh/id_rsa' -> '~/.ssh/id_git_rsa' へ

### DIFF
--- a/practice/README.md
+++ b/practice/README.md
@@ -110,8 +110,8 @@ Agent pid 85934
 
 ## ssh-agentに秘密鍵を登録
 [hayasaki-shunsuke@PMAC873S] ~/.ssh
-% ssh-add ~/.ssh/id_rsa
-Enter passphrase for /Users/hayasaki-shunsuke/.ssh/id_rsa:
+% ssh-add ~/.ssh/id_git_rsa
+Enter passphrase for /Users/hayasaki-shunsuke/.ssh/id_git_rsa:
 
 [hayasaki-shunsuke@PMAC873S] ~/.ssh
 % ssh-add ~/.ssh/id_git_rsa


### PR DESCRIPTION
表題の通り、一部ファイル名が`id_rsa`になっていたので`id_git_rsa`に修正しました！